### PR TITLE
Add RequestBodyEnforcer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,4 +34,5 @@ issues:
     - linters:
         - gomnd
         - goconst
+        - dupl
       path: "_test.go"

--- a/openapi3/reflect.go
+++ b/openapi3/reflect.go
@@ -72,6 +72,7 @@ const (
 // RequestBodyEnforcer enables request body for GET and HEAD methods.
 //
 // Should be implemented on input structure, function body can be empty.
+// Forcing request body is not recommended and should only be used for backwards compatibility.
 type RequestBodyEnforcer interface {
 	ForceRequestBody()
 }

--- a/openapi3/reflect.go
+++ b/openapi3/reflect.go
@@ -69,11 +69,19 @@ const (
 	mimeMultipart      = "multipart/form-data"
 )
 
+// RequestBodyEnforcer enables request body for GET and HEAD methods.
+//
+// Should be implemented on input structure, function body can be empty.
+type RequestBodyEnforcer interface {
+	ForceRequestBody()
+}
+
 func (r *Reflector) parseRequestBody(o *Operation, input interface{}, tag, mime string, httpMethod string) error {
 	httpMethod = strings.ToUpper(httpMethod)
+	_, forceRequestBody := input.(RequestBodyEnforcer)
 
 	// GET and HEAD requests should not have body.
-	if httpMethod == http.MethodGet || httpMethod == http.MethodHead {
+	if (httpMethod == http.MethodGet || httpMethod == http.MethodHead) && !forceRequestBody {
 		return nil
 	}
 


### PR DESCRIPTION
In some situations existing API is violating HTTP guidelines and uses GET or HEAD with request body.

This PR enables a workaround to allow such configurations by implementing empty `ForceRequestBody()` function on input structure.