### PR TITLE
Ignore json tags if formData is present in request body structure

### DIFF
--- a/openapi3/_testdata/req_schema.json
+++ b/openapi3/_testdata/req_schema.json
@@ -1,11 +1,14 @@
 {
-  "properties": {
-    "in_body1": {
-      "type": "integer"
-    },
-    "in_body2": {
-      "type": "string"
-    }
+  "properties":{
+    "in_form1":{"type":"string"},"in_form2":{"type":"string"},
+    "upload1":{"$ref":"#/components/schemas/FormDataMultipartFile"},
+    "upload2":{"$ref":"#/components/schemas/FormDataMultipartFileHeader"}
   },
-  "type": "object"
+  "type":"object",
+  "components":{
+    "schemas":{
+      "FormDataMultipartFile":{"type":["string","null"],"format":"binary"},
+      "FormDataMultipartFileHeader":{"type":["string","null"],"format":"binary"}
+    }
+  }
 }


### PR DESCRIPTION
Currently, if both types of tags are defined on fields, schemas for both `formData` and `json` will be create with separate content types. This not a commonly desired outcome as usually only one type is needed, while `json` can also be defined for other needs.

This PR adds a check to ignore `json` in such case, also it adds a lebeling interface to restore original behavior for edge cases.