### PR TITLE
Remove experimental disclaimer from openapi31 package

### DIFF
--- a/openapi31/doc.go
+++ b/openapi31/doc.go
@@ -1,6 +1,2 @@
 // Package openapi31 provides entities and helpers to manage OpenAPI 3.1.x schema.
-//
-// PLEASE NOTE: this package is currently experimental and may have backwards incompatible API changes in near future.
-// API would be considered stable, once this disclaimer is removed.
-// Give it a try and file issues if you face any.
 package openapi31


### PR DESCRIPTION
Package `openapi31` haven't received any bug reports or other issue since a long time, seems it is stable enough.