### PR TITLE
Fix null type in openapi31 parameter schemas for non-pointer types

### DIFF
--- a/openapi31/reflect.go
+++ b/openapi31/reflect.go
@@ -432,6 +432,13 @@ func (r *Reflector) parseParametersIn(
 			propertySchema := params.PropertySchema
 			field := params.Field
 
+			// HTTP parameters cannot be null (only absent), so remove null type
+			// for non-pointer, non-ref fields. This mirrors the openapi3 reflector behavior
+			// (s.Schema != nil && s.Schema.Nullable != nil && field.Type.Kind() != reflect.Ptr).
+			if propertySchema.Ref == nil && field.Type.Kind() != reflect.Ptr {
+				propertySchema.RemoveType(jsonschema.Null)
+			}
+
 			sm, err := propertySchema.ToSchemaOrBool().ToSimpleMap()
 			if err != nil {
 				return err

--- a/openapi31/reflect_test.go
+++ b/openapi31/reflect_test.go
@@ -507,7 +507,7 @@ func TestReflector_AddOperation_request_queryObject(t *testing.T) {
 			  {
 				"name":"in_query","in":"query",
 				"schema":{
-				  "additionalProperties":{"type":"number"},"type":["object","null"]
+				  "additionalProperties":{"type":"number"},"type":"object"
 				},
 				"style":"deepObject","explode":true
 			  }
@@ -608,7 +608,7 @@ func TestReflector_AddOperation_request_jsonQuery(t *testing.T) {
 				"name":"three","in":"query",
 				"schema":{
 				  "additionalProperties":{"type":"integer"},
-				  "type":["object","null"]
+				  "type":"object"
 				},
 				"style":"deepObject","explode":true
 			  },

--- a/openapi31/testdata/openapi.json
+++ b/openapi31/testdata/openapi.json
@@ -44,17 +44,17 @@
       "name":"in_query3","in":"query","description":"Query parameter.","required":true,
       "schema":{"description":"Query parameter.","type":"integer"}
      },
-     {"name":"array_csv","in":"query","schema":{"items":{"type":"string"},"type":["array","null"]},"explode":false},
+     {"name":"array_csv","in":"query","schema":{"items":{"type":"string"},"type":"array"},"explode":false},
      {
-      "name":"array_swg2_csv","in":"query","schema":{"items":{"type":"string"},"type":["array","null"]},"style":"form",
+      "name":"array_swg2_csv","in":"query","schema":{"items":{"type":"string"},"type":"array"},"style":"form",
       "explode":false
      },
      {
-      "name":"array_swg2_ssv","in":"query","schema":{"items":{"type":"string"},"type":["array","null"]},
+      "name":"array_swg2_ssv","in":"query","schema":{"items":{"type":"string"},"type":"array"},
       "style":"spaceDelimited","explode":false
      },
      {
-      "name":"array_swg2_pipes","in":"query","schema":{"items":{"type":"string"},"type":["array","null"]},
+      "name":"array_swg2_pipes","in":"query","schema":{"items":{"type":"string"},"type":"array"},
       "style":"pipeDelimited","explode":false
      },
      {"name":"in_path","in":"path","required":true,"schema":{"type":"integer"}},


### PR DESCRIPTION
## Problem

When a Go struct field is a slice (e.g. `[]int`) or a map (e.g. `map[string]int`) used as a query/path/header/cookie parameter, the OpenAPI 3.1 reflector generates a schema with `type: ["array","null"]` or `type: ["object","null"]`:

```yaml
parameters:
  - name: ids
    in: query
    required: true
    schema:
      items:
        type: integer
      type:
        - array
        - "null"   # ← incorrect for HTTP parameters
```

HTTP parameters cannot be `null` — they can only be **present** or **absent**. Allowing `null` in the schema is semantically incorrect and conflicts with the `required: true` constraint.

---

## Root Cause

The `jsonschema-go` library correctly marks Go slices and maps as nullable in `checkNullability()`, because Go slices/maps can be `nil`. This is valid for JSON body schemas.

However, the **openapi3** reflector already strips this for parameter schemas:

```go
// openapi3/reflect.go
s.FromJSONSchema(propertySchema.ToSchemaOrBool())
if s.Schema != nil && s.Schema.Nullable != nil && field.Type.Kind() != reflect.Ptr {
    s.Schema.Nullable = nil  // strips nullable for non-pointer param fields
}
```

The **openapi31** reflector was **never updated** with the equivalent logic. In OAS 3.1, `nullable: true` is replaced by `type: ["X","null"]` (per JSON Schema), so the stripping must use `RemoveType` instead.

---

## Fix

Added the equivalent null-removal logic to `openapi31/reflect.go`:

```go
// mirrors openapi3 behavior: s.Schema != nil && s.Schema.Nullable != nil && field.Type.Kind() != reflect.Ptr
if propertySchema.Ref == nil && field.Type.Kind() != reflect.Ptr {
    propertySchema.RemoveType(jsonschema.Null)
}
```
---

## Before / After

**Before:**
```yaml
parameters:
  - name: ids
    in: query
    schema:
      items:
        type: integer
      type:
        - array
        - "null"
```

**After:**
```yaml
parameters:
  - name: ids
    in: query
    schema:
      items:
        type: integer
      type: array
```

Response body schemas are **unaffected** — slices/maps in response bodies still correctly generate `type: ["array","null"]`.

---

## Testing

- Updated `openapi31/testdata/openapi.json` — 4 array query params and 2 map query params now show non-nullable types
- All existing tests pass: `go test ./...`
